### PR TITLE
Add consistent ISO/TC 211 Resources nav link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: ISO/TC 211 Registries
 title_html: "ISO/TC&nbsp;211 Registries"
-brand_sub: "Geodetic Registry"
+brand_sub: "Harmonized Resources Maintenance Agency"
 
 theme: jekyll-theme-isotc211
 
@@ -33,7 +33,7 @@ plugins:
   - jekyll-asciidoc
 
 nav:
-  - title: ISO/TC 211
+  - title: ISO/TC 211 Resources
     url: https://www.isotc211.org
 
 footer_links:


### PR DESCRIPTION
Updates nav label to "ISO/TC 211 Resources" for consistency across all TC 211 sites. Requires ISO-TC211/jekyll-theme-isotc211#9 for external-link icon rendering.