### PR TITLE
feat: add News section with nav entry

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,8 @@ plugins:
   - jekyll-asciidoc
 
 nav:
+  - title: News
+    url: /news/
   - title: ISO/TC 211 Resources
     url: https://www.isotc211.org
 

--- a/source/news/index.html
+++ b/source/news/index.html
@@ -1,0 +1,4 @@
+---
+layout: posts
+title: News
+---


### PR DESCRIPTION
Adds a /news/ page using the posts layout and a 'News' nav link in the header, consistent with the other ISO/TC 211 sites.